### PR TITLE
Add support for Mikrotik RouterOS v6 >= v6.49

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Currently only `VirtualBox` provider is available.
 
 #### Security
 By default the boxes have no firewall rules configured and come with two user accounts:
-* `admin` with empty(!) password
+* `admin` with `vagrant` (!) password
 * `vagrant` with password `vagrant` and Vagrant insecure private key authentication enabled
 
 :warning: This unsecure setup is intended for use in isolated testing environments. To secure

--- a/routeros.json
+++ b/routeros.json
@@ -29,6 +29,9 @@
         "<enter><wait><wait>",
         "n<wait><wait>",
         "<enter><wait5>",
+        "vagrant<wait><enter>",
+        "vagrant<wait><enter>",
+        "<wait5>",
         "/ip dhcp-client add disabled=no interface=ether1 add-default-route=no use-peer-dns=no use-peer-ntp=no<enter>",
         "<wait5>",
         ":global packerHost \"http://{{ .HTTPIP }}:{{ .HTTPPort }}\"<enter>",
@@ -40,7 +43,7 @@
       "guest_additions_mode": "disable",
       "virtualbox_version_file": "",
       "ssh_username": "admin",
-      "ssh_password": "",
+      "ssh_password": "vagrant",
       "ssh_wait_timeout": "60s",
       "shutdown_command": "execute \"/system shutdown\"",
       "format": "ova"


### PR DESCRIPTION
This pull request adds support for Mikrotik RouterOS v6.49 and higher. They require changing the `admin` password at first login, so I changed the default `admin` password to `vagrant`.

The template works even for older RouterOS versions. It won't work for RouterOS 7.