### PR TITLE
Add support for RouterOS v7

### DIFF
--- a/routeros7.json
+++ b/routeros7.json
@@ -1,0 +1,65 @@
+{
+  "variables": {
+    "ros_ver": "",
+    "box_file_name": "build/boxes/routeros.box"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "vm_name": "routeros",
+      "disk_size": "256",
+      "guest_os_type": "Linux_64",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "128"],
+        ["modifyvm", "{{.Name}}", "--acpi", "on"],
+        ["modifyvm", "{{.Name}}", "--ioapic", "on"],
+        ["modifyvm", "{{.Name}}", "--hpet", "on"],
+        ["modifyvm", "{{.Name}}", "--rtcuseutc", "on"],
+        ["modifyvm", "{{.Name}}", "--pae", "on"],
+        ["modifyvm", "{{.Name}}", "--usb", "on"],
+        ["modifyvm", "{{.Name}}", "--usbehci", "off"]
+      ],
+      "iso_url": "https://download.mikrotik.com/routeros/{{user `ros_ver`}}/mikrotik-{{user `ros_ver`}}.iso",
+      "iso_checksum": "none",
+      "http_directory": ".",
+      "boot_command": [
+        "<wait5>a<wait>i<wait>y<wait10><wait10><enter>",
+        "<wait10><wait10><wait10>",
+        "admin<enter><wait><wait>",
+        "<enter><wait><wait>",
+        "n<wait><wait>",
+        "<enter><wait5>",
+        "vagrant<wait><enter>",
+        "vagrant<wait><enter>",
+        "<wait5>",
+        "/ip dhcp-client add disabled=no interface=ether1 add-default-route=no use-peer-dns=no use-peer-ntp=no<enter>",
+        "<wait5>",
+        ":global packerHost \"http://{{ .HTTPIP }}:{{ .HTTPPort }}\"<enter>",
+        "/tool fetch url=\"$packerHost/setup7.rsc\" keep-result=yes dst-path=\"setup.rsc\"<enter>",
+        "<wait5>",
+        "/import setup.rsc<enter>",
+        "<wait10><wait10><wait10>"
+      ],
+      "guest_additions_mode": "disable",
+      "virtualbox_version_file": "",
+      "ssh_username": "admin",
+      "ssh_password": "vagrant",
+      "ssh_wait_timeout": "60s",
+      "shutdown_command": "execute \"/system shutdown\"",
+      "format": "ova"
+    }
+  ],
+  "post-processors": [
+    {
+      "type": "vagrant",
+      "keep_input_artifact": false,
+      "compression_level": 9,
+      "output": "{{ user `box_file_name`}}",
+      "vagrantfile_template": "vagrantfile.template",
+      "include": [
+        "vagrant-plugins-routeros/pkg/vagrant-routeros-{{user `vagrant_routeros_plugin_version`}}.gem",
+        "vagrant-plugins-routeros/vagrant_routeros_plugin_version.json"
+      ]
+    }
+  ]
+}

--- a/setup7.rsc
+++ b/setup7.rsc
@@ -1,0 +1,13 @@
+:global packerHost
+:put "Fetching $packerHost/vagrant_insecure.key"
+/tool fetch url="$packerHost/vagrant_insecure.key" keep-result=yes dst-path="vagrant.key"
+:delay 5
+
+:put "Adding 'vagrant' user"
+/user add name=vagrant password=vagrant group=full
+/user ssh-keys import user=vagrant public-key-file=vagrant.key
+
+:put "Fetching $packerHost/vagrant_provision.rsc"
+/tool fetch url="$packerHost/vagrant_provision.rsc" keep-result=yes dst-path="vagrant_provision.rsc"
+
+/file remove setup.rsc


### PR DESCRIPTION
This merge request adds support for RouterOS v7 in packer template file. The installation and the `setup.rsc` have been changed to accomodate routeros changes.

Unfortunately I had no time to test the ruby gem nor fixing the python script.